### PR TITLE
Add UI metadata to Stepper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 
 buildscript {
-    ext.cubaVersion = '7.2.4'
+    ext.cubaVersion = '7.2.6'
     repositories {
         
         maven {

--- a/modules/web/src/com/company/demo/web-screens.xml
+++ b/modules/web/src/com/company/demo/web-screens.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <screen-config xmlns="http://schemas.haulmont.com/cuba/screens.xsd">
 
-    <screen id="demo$Customer.browse" template="com/company/demo/web/customer/customer-browse.xml"/>
-    <screen id="demo$Customer.edit" template="com/company/demo/web/customer/customer-edit.xml"/>
 </screen-config>

--- a/modules/web/src/com/company/demo/web/customer/CustomerBrowse.java
+++ b/modules/web/src/com/company/demo/web/customer/CustomerBrowse.java
@@ -1,6 +1,11 @@
 package com.company.demo.web.customer;
 
-import com.haulmont.cuba.gui.components.AbstractLookup;
+import com.company.demo.entity.Customer;
+import com.haulmont.cuba.gui.screen.*;
 
-public class CustomerBrowse extends AbstractLookup {
+@UiController("demo$Customer.browse")
+@UiDescriptor("customer-browse.xml")
+@LookupComponent("customersTable")
+@LoadDataBeforeShow
+public class CustomerBrowse extends StandardLookup<Customer> {
 }

--- a/modules/web/src/com/company/demo/web/customer/CustomerEdit.java
+++ b/modules/web/src/com/company/demo/web/customer/CustomerEdit.java
@@ -1,11 +1,15 @@
 package com.company.demo.web.customer;
 
-import com.haulmont.cuba.gui.components.AbstractEditor;
 import com.company.demo.entity.Customer;
+import com.haulmont.cuba.gui.screen.*;
 
-public class CustomerEdit extends AbstractEditor<Customer> {
-    @Override
-    protected void initNewItem(Customer item) {
-        item.setScore(0);
+@UiController("demo$Customer.edit")
+@UiDescriptor("customer-edit.xml")
+@EditedEntityContainer("customerDc")
+@LoadDataBeforeShow
+public class CustomerEdit extends StandardEditor<Customer> {
+    @Subscribe
+    public void onInitEntity(InitEntityEvent<Customer> event) {
+        event.getEntity().setScore(0);
     }
 }

--- a/modules/web/src/com/company/demo/web/customer/customer-browse.xml
+++ b/modules/web/src/com/company/demo/web/customer/customer-browse.xml
@@ -1,42 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<window xmlns="http://schemas.haulmont.com/cuba/window.xsd"
+<window xmlns="http://schemas.haulmont.com/cuba/screen/window.xsd"
         caption="msg://browseCaption"
-        class="com.company.demo.web.customer.CustomerBrowse"
         focusComponent="customersTable"
-        lookupComponent="customersTable"
         messagesPack="com.company.demo.web.customer">
-    <dsContext>
-        <groupDatasource id="customersDs"
+    <data>
+        <collection id="customersDc"
                          class="com.company.demo.entity.Customer"
                          view="_local">
-            <query>
-                <![CDATA[select e from demo$Customer e]]>
-            </query>
-        </groupDatasource>
-    </dsContext>
+            <loader id="customersDl">
+                <query>
+                    <![CDATA[select e from demo$Customer e]]>
+                </query>
+            </loader>
+        </collection>
+    </data>
     <dialogMode height="600"
                 width="800"/>
     <layout expand="customersTable"
             spacing="true">
         <filter id="filter"
                 applyTo="customersTable"
-                datasource="customersDs">
+                dataLoader="customersDl">
             <properties include=".*"/>
         </filter>
         <groupTable id="customersTable"
-                    width="100%">
+                    width="100%" dataContainer="customersDc">
             <actions>
-                <action id="create"
-                        openType="NEW_TAB"/>
-                <action id="edit"
-                        openType="NEW_TAB"/>
-                <action id="remove"/>
+                <action id="create" type="create"/>
+                <action id="edit" type="edit"/>
+                <action id="remove" type="remove"/>
             </actions>
             <columns>
                 <column id="name"/>
                 <column id="score"/>
             </columns>
-            <rows datasource="customersDs"/>
             <rowsCount/>
             <buttonsPanel id="buttonsPanel"
                           alwaysVisible="true">
@@ -45,5 +42,11 @@
                 <button id="removeBtn" action="customersTable.remove"/>
             </buttonsPanel>
         </groupTable>
+        <hbox id="lookupActions"
+              spacing="true"
+              visible="false">
+            <button action="lookupSelectAction"/>
+            <button action="lookupCancelAction"/>
+        </hbox>
     </layout>
 </window>

--- a/modules/web/src/com/company/demo/web/customer/customer-edit.xml
+++ b/modules/web/src/com/company/demo/web/customer/customer-edit.xml
@@ -1,30 +1,31 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<window xmlns="http://schemas.haulmont.com/cuba/window.xsd"
+<window xmlns="http://schemas.haulmont.com/cuba/screen/window.xsd"
         xmlns:app="http://schemas.company.com/demo/0.1/ui-component.xsd"
         caption="msg://editorCaption"
-        class="com.company.demo.web.customer.CustomerEdit"
-        datasource="customerDs"
         focusComponent="fieldGroup"
         messagesPack="com.company.demo.web.customer">
-    <dsContext>
-        <datasource id="customerDs"
-                    class="com.company.demo.entity.Customer"
-                    view="_local"/>
-    </dsContext>
+    <data>
+        <instance id="customerDc"
+                  class="com.company.demo.entity.Customer"
+                  view="_local">
+            <loader id="customerDl"/>
+        </instance>
+    </data>
     <dialogMode height="600"
                 width="800"/>
-    <layout expand="windowActions" spacing="true">
-        <fieldGroup id="fieldGroup" datasource="customerDs">
+    <layout expand="editActions" spacing="true">
+        <form id="fieldGroup" dataContainer="customerDc">
             <column width="250px">
-                <field property="name"/>
-                <field id="score">
-                    <app:stepper id="stepper" caption="Score"
-                                 datasource="customerDs" property="score"
-                                 minValue="1" maxValue="20"/>
-                </field>
+                <textField property="name"/>
+                <app:stepper id="score" caption="Score"
+                             dataContainer="customerDc"
+                             property="score"/>
             </column>
-        </fieldGroup>
-        <frame id="windowActions"
-               screen="editWindowActions"/>
+        </form>
+        <hbox id="editActions"
+              spacing="true">
+            <button action="windowCommitAndClose"/>
+            <button action="windowClose"/>
+        </hbox>
     </layout>
 </window>

--- a/modules/web/src/com/company/demo/web/gui/components/Stepper.java
+++ b/modules/web/src/com/company/demo/web/gui/components/Stepper.java
@@ -1,24 +1,45 @@
 package com.company.demo.web.gui.components;
 
 import com.haulmont.cuba.gui.components.Field;
+import com.haulmont.cuba.gui.meta.PropertyType;
+import com.haulmont.cuba.gui.meta.StudioComponent;
+import com.haulmont.cuba.gui.meta.StudioProperties;
+import com.haulmont.cuba.gui.meta.StudioProperty;
+
+import javax.validation.constraints.Positive;
 
 // note that Stepper should extend Field
+@StudioComponent(category = "Samples",
+        unsupportedProperties = {"description", "icon", "responsive"},
+        xmlns = "http://schemas.company.com/demo/0.1/ui-component.xsd",
+        xmlnsAlias = "app",
+        icon = "com/company/demo/web/gui/components/icons/stepper.svg")
+@StudioProperties(properties = {
+        @StudioProperty(name = "datasource", type = PropertyType.DATASOURCE_REF),
+        @StudioProperty(name = "property", type = PropertyType.PROPERTY_PATH_REF, options = "int"),
+})
 public interface Stepper extends Field<Integer> {
 
     String NAME = "stepper";
 
-    boolean isManualInputAllowed();
+    @StudioProperty(name = "manualInput", type = PropertyType.BOOLEAN, defaultValue = "true")
     void setManualInputAllowed(boolean value);
+    boolean isManualInputAllowed();
 
-    boolean isMouseWheelEnabled();
+    @StudioProperty(name = "mouseWheel", type = PropertyType.BOOLEAN, defaultValue = "true")
     void setMouseWheelEnabled(boolean value);
+    boolean isMouseWheelEnabled();
 
-    int getStepAmount();
+    @StudioProperty(type = PropertyType.INTEGER, defaultValue = "1")
+    @Positive
     void setStepAmount(int amount);
+    int getStepAmount();
 
-    int getMaxValue();
+    @StudioProperty(type = PropertyType.INTEGER)
     void setMaxValue(int maxValue);
+    int getMaxValue();
 
-    int getMinValue();
+    @StudioProperty(type = PropertyType.INTEGER)
     void setMinValue(int minValue);
+    int getMinValue();
 }

--- a/modules/web/src/com/company/demo/web/gui/components/Stepper.java
+++ b/modules/web/src/com/company/demo/web/gui/components/Stepper.java
@@ -1,10 +1,7 @@
 package com.company.demo.web.gui.components;
 
 import com.haulmont.cuba.gui.components.Field;
-import com.haulmont.cuba.gui.meta.PropertyType;
-import com.haulmont.cuba.gui.meta.StudioComponent;
-import com.haulmont.cuba.gui.meta.StudioProperties;
-import com.haulmont.cuba.gui.meta.StudioProperty;
+import com.haulmont.cuba.gui.meta.*;
 
 import javax.validation.constraints.Positive;
 
@@ -13,11 +10,14 @@ import javax.validation.constraints.Positive;
         unsupportedProperties = {"description", "icon", "responsive"},
         xmlns = "http://schemas.company.com/demo/0.1/ui-component.xsd",
         xmlnsAlias = "app",
-        icon = "com/company/demo/web/gui/components/icons/stepper.svg")
+        icon = "com/company/demo/web/gui/components/icons/stepper.svg",
+        canvasBehaviour = CanvasBehaviour.INPUT_FIELD)
 @StudioProperties(properties = {
         @StudioProperty(name = "dataContainer", type = PropertyType.DATACONTAINER_REF),
         @StudioProperty(name = "property", type = PropertyType.PROPERTY_PATH_REF, options = "int"),
-})
+}, groups = @PropertiesGroup(
+        properties = {"dataContainer", "property"}, constraint = PropertiesConstraint.ALL_OR_NOTHING
+))
 public interface Stepper extends Field<Integer> {
 
     String NAME = "stepper";

--- a/modules/web/src/com/company/demo/web/gui/components/Stepper.java
+++ b/modules/web/src/com/company/demo/web/gui/components/Stepper.java
@@ -15,7 +15,7 @@ import javax.validation.constraints.Positive;
         xmlnsAlias = "app",
         icon = "com/company/demo/web/gui/components/icons/stepper.svg")
 @StudioProperties(properties = {
-        @StudioProperty(name = "datasource", type = PropertyType.DATASOURCE_REF),
+        @StudioProperty(name = "dataContainer", type = PropertyType.DATACONTAINER_REF),
         @StudioProperty(name = "property", type = PropertyType.PROPERTY_PATH_REF, options = "int"),
 })
 public interface Stepper extends Field<Integer> {

--- a/modules/web/src/com/company/demo/web/gui/components/icons/stepper.svg
+++ b/modules/web/src/com/company/demo/web/gui/components/icons/stepper.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333333 4.2333333"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="stepper.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.678384"
+     inkscape:cx="-3.2260623"
+     inkscape:cy="7.7602649"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     scale-x="1"
+     units="px"
+     inkscape:window-width="1848"
+     inkscape:window-height="1016"
+     inkscape:window-x="72"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1414"
+       empspacing="5" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-292.76666)">
+    <path
+       style="fill:none;stroke:#9aa7b0;stroke-width:0.44996491;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 1.2855936,294.39149 2.074614,293.60268"
+       id="path5137"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#9aa7b0;stroke-width:0.45131001;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.0800216,293.59977 0.791523,0.79104"
+       id="path5141"
+       inkscape:connector-curvature="0"
+       inkscape:transform-center-x="0.11809132"
+       inkscape:transform-center-y="0.028613566" />
+    <path
+       style="fill:none;stroke:#9aa7b0;stroke-width:0.45032936;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.0384556,296.28454 0.7914551,-0.79097"
+       id="path5137-6"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#9aa7b0;stroke-width:0.4493694;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 1.244221,295.4956 0.7896247,0.78942"
+       id="path5141-7"
+       inkscape:connector-curvature="0"
+       inkscape:transform-center-x="0.11780815"
+       inkscape:transform-center-y="0.028561031" />
+  </g>
+</svg>

--- a/modules/web/src/com/company/demo/web/gui/components/icons/stepper_dark.svg
+++ b/modules/web/src/com/company/demo/web/gui/components/icons/stepper_dark.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 4.2333333 4.2333333"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)"
+   sodipodi:docname="stepper_dark.svg">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="31.678384"
+     inkscape:cx="-4.9967281"
+     inkscape:cy="1.6794391"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     scale-x="1"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1043"
+     inkscape:window-x="1920"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:pagecheckerboard="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1414"
+       empspacing="5" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-292.76666)">
+    <path
+       style="fill:none;stroke:#afb1b3;stroke-width:0.47965106;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 1.3113542,294.36562 0.7648625,-0.76373"
+       id="path5137"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#afb1b3;stroke-width:0.47966856;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.105064,293.6018 0.7640543,0.76398"
+       id="path5141"
+       inkscape:connector-curvature="0"
+       inkscape:transform-center-x="0.11399304"
+       inkscape:transform-center-y="0.027637193" />
+    <path
+       style="fill:none;stroke:#afb1b3;stroke-width:0.47878245;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.0938948,296.229 0.7600047,-0.7601"
+       id="path5137-6"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#afb1b3;stroke-width:0.47863427;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke"
+       d="m 1.3001365,295.46894 0.7599917,0.76008"
+       id="path5141-7"
+       inkscape:connector-curvature="0"
+       inkscape:transform-center-x="0.11338692"
+       inkscape:transform-center-y="0.027495808" />
+  </g>
+</svg>

--- a/modules/web/src/ui-component.xsd
+++ b/modules/web/src/ui-component.xsd
@@ -10,7 +10,7 @@
             <xs:attribute name="caption" type="xs:string"/>
             <xs:attribute name="width" type="xs:string"/>
             <xs:attribute name="height" type="xs:string"/>
-            <xs:attribute name="datasource" type="xs:string"/>
+            <xs:attribute name="dataContainer" type="xs:string"/>
             <xs:attribute name="property" type="xs:string"/>
             <xs:attribute name="manualInput" type="xs:boolean"/>
             <xs:attribute name="mouseWheel" type="xs:boolean"/>


### PR DESCRIPTION
- Add UI metadata to Stepper, it will be referenced in documentation as an example of adding UI annotations to custom components
- Migrate screens to CUBA 7 API, to get rid of fieldGroup (Studio doesn't work well with fieldGroup fields)